### PR TITLE
Update UsbHid.java

### DIFF
--- a/src/android/UsbHid.java
+++ b/src/android/UsbHid.java
@@ -89,7 +89,7 @@ public class UsbHid extends CordovaPlugin {
         return false;
     }
 
-    private void enumerateDevices(CallbackContext callbackContext) {
+    private void enumerateDevices(final CallbackContext callbackContext) {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {


### PR DESCRIPTION
The final keyword fixes error:
\platforms\android\src\org\vangulik\usb\hid\UsbHid.java:111: error: local variable callbackContext is accessed from within inner class; needs to be declared final
callbackContext.success(result);